### PR TITLE
Enable tsconfig.json source mapping for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,32 @@ testing database each time you have new ones, you can do this by running the com
 Once you have all the above done you can run your tests with the following command: `npm test`. For more information refeer to the documentation of [Mocha](https://mochajs.org/) and [Chai](https://www.chaijs.com/).
 
 #### Debugging
-As we know, a NodeJS application is not something easy to debug and because of that we've added the `--inspect` flag to make it simpler. Chrome DevTools will get started when running your app using the start script (`npm start`), making your debugging easier.
+
+In order to debug our Node.js application, we enable 'sourceMap' in `tsconfig.json`, this compiler option generates corresponding `.map` files from original Javascipt counterpart. This change is mandatory to attach a debugger, otherwise it wouldn't be able to match transpiled files with their originals.
+
+In VSCode, you will need to add an `./.vscode/launch.json` file in order to launch the debugger. You can use the following:
+
+```json
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "program": "${workspaceFolder}/server.ts",
+      "preLaunchTask": "tsc: build - tsconfig.json",
+      "restart": true,
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ]
+    }
+  ]
+}
+```
 
 #### REPL console
 We can use a node console with `npm run console`. There your service objects are exposed as _servicename_ + "Service". Let's suppose that we have a service `users` which has a function `getAll`. In your console you can call `usersService.getAll()` and see the result. Note that this works also with functions that return promises! To exit the console use `.exit`.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,20 @@
 {
-    "compilerOptions": {
-        "allowJs": true,
-        "checkJs": false,
-        "esModuleInterop": true,
-        "downlevelIteration": true,
-        "lib": [
-            "esnext",
-            "dom"
-        ],
-        "module": "commonjs",
-        "noUnusedLocals": true,
-        "outDir": "dist",
-        "skipLibCheck": true,
-        "strict": true,
-        "strictFunctionTypes": false,
-        "strictPropertyInitialization": false,
-        "suppressImplicitAnyIndexErrors": true,
-        "target": "esnext"
-    },
-    "include": [
-        "./"
-    ]
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "esModuleInterop": true,
+    "downlevelIteration": true,
+    "lib": ["esnext", "dom"],
+    "module": "commonjs",
+    "noUnusedLocals": true,
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "strictFunctionTypes": false,
+    "strictPropertyInitialization": false,
+    "suppressImplicitAnyIndexErrors": true,
+    "target": "esnext"
+  },
+  "include": ["./"]
 }


### PR DESCRIPTION
## Summary

- Change `tsconfig.json` in order to enable source mapping. This change is necessary to attach a debugger, otherwise debugger wouldn't be able to match transpiled files with their originals.
- Fix tab size in config file (4~>2).

- For VSCode is necessary to add a `.vscode/launch.json` file but I don't include it in the PR (ignored by git) because there are people that do not use that editor but I can add it if you want.

## Known Issues

N/A