### PR TITLE
Fix error in eslint configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,10 +9,9 @@ module.exports = {
   "parserOptions": {
     "ecmaVersion": 2019,
     "sourceType": "module",
-    "ecmaFeatures": {
-      "jsx": false,
-    },
-    "project": "./tsconfig.json",
+    "project": './tsconfig.json',
+    "tsconfigRootDir": __dirname,
+    "createDefaultProgram": true
   },
   "plugins": [
     "@typescript-eslint/tslint"


### PR DESCRIPTION
## Summary

- Fix error in eslint config file. It cannot resolves `tsconfig` path and throws a linter error when creating a new file (error resolves when editor is reopen :miterio: :shipit:). Simply add a path resolver to the file in order to allow linter to find the file.

![image](https://user-images.githubusercontent.com/4696005/66006066-c5175480-e483-11e9-91cd-3e088834064b.png)

## Known Issues

N/A